### PR TITLE
Add French localization for 'Boss in' timer label

### DIFF
--- a/damageable/Damageable.lua
+++ b/damageable/Damageable.lua
@@ -607,9 +607,9 @@ end
 -- Display the timer
 function Crutch.DisplayDamageable(time, displayFormat)
     if (Crutch.savedOptions.general.consolidateDamageableInInfoPanel) then
-        Crutch.InfoPanel.CountDownDamageable(time, displayFormat or "Boss in ")
+        Crutch.InfoPanel.CountDownDamageable(time, displayFormat or GetString(CRUTCH_BOSS_IN))
     else
-        dmgDisplayFormat = displayFormat or "Boss in "
+        dmgDisplayFormat = displayFormat or GetString(CRUTCH_BOSS_IN)
         dmgDisplayFormat = dmgDisplayFormat .. "|c%s%.1f|r"
         pollTime = GetGameTimeMilliseconds() + time * 1000
         CrutchAlertsDamageableLabel:SetFont(Crutch.GetStyles().damageableFont)

--- a/infopanel/InfoPanelUtils.lua
+++ b/infopanel/InfoPanelUtils.lua
@@ -79,7 +79,7 @@ end
 function IP.CountDownDamageable(durationSeconds, prefix)
     CountDown(
         PANEL_DAMAGEABLE_INDEX,
-        prefix or "Boss in ",
+        prefix or GetString(CRUTCH_BOSS_IN),
         "|c0fff43Fire the nailguns!|r",
         durationSeconds * 1000,
         1000,

--- a/lang/default.lua
+++ b/lang/default.lua
@@ -1,4 +1,5 @@
 -- /script SetCVar("language.2", "en")
+ZO_CreateStringId("CRUTCH_BOSS_IN", "Boss in ")
 ZO_CreateStringId("CRUTCH_BHB_AGHAEDH_OF_THE_SOLSTICE", "Aghaedh of the Solstice")
 ZO_CreateStringId("CRUTCH_BHB_ANALA_TUWHA", "Anal'a Tu'wha")
 ZO_CreateStringId("CRUTCH_BHB_ANSUUL_THE_TORMENTOR", "Ansuul the Tormentor")

--- a/lang/fr.lua
+++ b/lang/fr.lua
@@ -1,4 +1,5 @@
 -- /script SetCVar("language.2", "fr")
+SafeAddString(CRUTCH_BOSS_IN, "Boss dans ")
 SafeAddString(CRUTCH_BHB_AGHAEDH_OF_THE_SOLSTICE, "Aghaedh du Solstice^F")
 SafeAddString(CRUTCH_BHB_ANALA_TUWHA, "Anal'a Tu'wha^m")
 SafeAddString(CRUTCH_BHB_ANSUUL_THE_TORMENTOR, "Ansuul la Tormentrice^F")


### PR DESCRIPTION
## Problem

When playing ESO with the game client set to French, the boss spawn countdown timer (\"Boss in: xx\") was not displaying because the label text was hardcoded in English only.

## Fix

- Added a `CRUTCH_BOSS_IN` localization key to `lang/default.lua` (English: `"Boss in "`)
- Added the French translation to `lang/fr.lua` (`"Boss dans "`)
- Replaced the hardcoded `"Boss in "` strings in `damageable/Damageable.lua` and `infopanel/InfoPanelUtils.lua` with `GetString(CRUTCH_BOSS_IN)`

The timer now correctly displays in French clients.